### PR TITLE
Uncomment Ethereum handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -4438,7 +4438,7 @@ try {
   if (o.host === 'login.exokit.org') {
     _handleLogin(req, res);
     return;
-  } else if (o.host === 'ethereum.exokit.org') {
+  } else if (o.host === 'ethereums.exokit.org') {
     _handleEthereum(req, res);
     return;
   /* } else if (o.host === 'presence.exokit.org') {


### PR DESCRIPTION
This PR uncomments the ethereum handling, previous removed at https://github.com/webaverse/api-backend/commit/324d3c6a816d0a362f75ccae1dd411bd3cc41889, this re-adds the HTTPS proxy for the GETH node at https://ethereums.exokit.org 