### PR TITLE
add sha3 -> sha3Raw for filename and description hashes

### DIFF
--- a/routes/sign.js
+++ b/routes/sign.js
@@ -183,8 +183,8 @@ const _handleSignRequest = async (req, res) => {
                               v: new web3[chainName].utils.BN(chainIds[oppositeChainName][contractName]),
                             };
 
-                            const filenameHash = web3[chainName].utils.sha3(filename.v);
-                            const descriptionHash = web3[chainName].utils.sha3(description.v);
+                            const filenameHash = web3[chainName].utils.sha3Raw(filename.v);
+                            const descriptionHash = web3[chainName].utils.sha3Raw(description.v);
                             // console.log('sign', {tokenId: log.tokenId, hashSpec, toInverse, tokenId, hash, filenameHash, timestamp, chainId});
                             const message = web3[chainName].utils.encodePacked(to, tokenId, hash, filenameHash, descriptionHash, timestamp, chainId);
                             const hashedMessage = web3[chainName].utils.sha3(message);


### PR DESCRIPTION
> Error: null is not a number

The normal sha3 returns null for empty strings (if the filename or description is empty) - https://web3js.readthedocs.io/en/v1.2.11/web3-utils.html#sha3

The sha3Raw function hashes regardless instead of returning null for empty strings - https://web3js.readthedocs.io/en/v1.2.11/web3-utils.html#sha3raw