### PR TITLE
update sign route for new contracts

### DIFF
--- a/routes/sign.js
+++ b/routes/sign.js
@@ -155,24 +155,6 @@ const _handleSignRequest = async (req, res) => {
                               v: new web3[chainName].utils.BN(log.topics[2].slice(2), 16),
                             };
                             
-                            const hashSpec = await contracts[chainName][contractName].methods.getHash(tokenId.v).call();
-                            const hash = {
-                              t: 'uint256',
-                              v: new web3[chainName].utils.BN(hashSpec),
-                            };
-                            const filenameSpec = await contracts[chainName][contractName].methods.getMetadata(hashSpec, 'filename').call() || '';
-                            const filename = {
-                              t: 'string',
-                              v: filenameSpec,
-                            };
-
-                            const descriptionSpec = await contracts[chainName][contractName].methods.getMetadata(hashSpec, 'description').call() || '';
-                            const description = {
-                              t: 'string',
-                              v: descriptionSpec,
-                            };
-                            // console.log('got filename hash', hash, filename);
-
                             // get sidechain deposit receipt signature
                             const timestamp = {
                               t: 'uint256',
@@ -183,10 +165,7 @@ const _handleSignRequest = async (req, res) => {
                               v: new web3[chainName].utils.BN(chainIds[oppositeChainName][contractName]),
                             };
 
-                            const filenameHash = web3[chainName].utils.sha3Raw(filename.v);
-                            const descriptionHash = web3[chainName].utils.sha3Raw(description.v);
-                            // console.log('sign', {tokenId: log.tokenId, hashSpec, toInverse, tokenId, hash, filenameHash, timestamp, chainId});
-                            const message = web3[chainName].utils.encodePacked(to, tokenId, hash, filenameHash, descriptionHash, timestamp, chainId);
+                            const message = web3[chainName].utils.encodePacked(to, tokenId, timestamp, chainId);
                             const hashedMessage = web3[chainName].utils.sha3(message);
                             const sgn = web3[chainName].eth.accounts.sign(hashedMessage, wallet.getPrivateKeyString()); // await web3.eth.personal.sign(hashedMessage, address);
                             const {r, s, v} = sgn;
@@ -197,9 +176,6 @@ const _handleSignRequest = async (req, res) => {
                             res.end(JSON.stringify({
                               to: to.v,
                               tokenId: '0x' + web3[chainName].utils.padLeft(tokenId.v.toString(16), 32),
-                              hash: '0x' + web3[chainName].utils.padLeft(hash.v.toString(16), 32),
-                              filenameHash,
-                              descriptionHash,
                               timestamp: timestamp.v,
                               chainId: chainId.v.toNumber(),
                               r,


### PR DESCRIPTION
These metadata fields are no longer needed for the new contracts: https://github.com/webaverse/api-backend/blob/4f519e38062645728a8a8767517f51c0d1606df6/routes/sign.js#L200-L202


The removal of fields from the contracts:
https://github.com/webaverse/contracts/commit/324f70f59cb3f5448bcb14458a763de67f11d8f1#diff-2355c3c479e71d0859386e7c5a5dd043efeda369e2c892ee6e1ad5c540139267L38-R39