### PR TITLE
fix paginated token id

### DIFF
--- a/index.js
+++ b/index.js
@@ -1389,7 +1389,7 @@ try {
         const numTokens = endTokenId - startTokenId;
         const promises = Array(numTokens);
         for (let i = 0; i < numTokens; i++) {
-          promises[i] = _getSidechainToken(tokenId, storeEntries);
+          promises[i] = _getSidechainToken(startTokenId + i, storeEntries);
         }
         let tokens = await Promise.all(promises);
         tokens = tokens.filter(token => token !== null);


### PR DESCRIPTION
This PR fixes the variable passed in for the token id when making a paginated token api call like http://tokens.webaverse.com/1-100