### PR TITLE
Use correct parameters in getPastEvents()

### DIFF
--- a/blockchain.js
+++ b/blockchain.js
@@ -170,12 +170,9 @@ async function getPastEvents({
   chainName,
   contractName,
   eventName,
-  /* fromBlock = 0,
-  toBlock = 'latest', */
+  fromBlock = 0,
+  toBlock = 'latest',
 } = {}) {
-  const fromBlock = 0;
-  const toBlock = 'latest';
-
   try {
     const {contracts} = await getBlockchain();
     return await contracts[chainName][contractName].getPastEvents(

--- a/cache.js
+++ b/cache.js
@@ -53,7 +53,7 @@ async function initNftCache({chainName}) {
     const events = await getPastEvents({
       chainName,
       contractName: 'NFT',
-      lastBlockNumber,
+      fromBlock: lastBlockNumber,
     });
     if (events.length > 0) {
       await processEventsNft({
@@ -117,7 +117,7 @@ async function initAccountCache({chainName}) {
     const events = await getPastEvents({
       chainName,
       contractName: 'Account',
-      lastBlockNumber,
+      fromBlock: lastBlockNumber,
     });
     if (events.length > 0) {
       await processEventsAccount({


### PR DESCRIPTION
@avaer Noticed you hardcoded fromBlock/toBlock in `getPastEvents`, but also were passing an `lastBlockNumber` instead of `fromBlock`, so if you were hardcoding because you couldn't get the fromBlock number to pass correctly, this is the fix. Otherwise feel free to close this PR.