### PR TITLE
Added Redirect URI as Query Parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -272,7 +272,7 @@ try {
     console.log('got login', JSON.stringify({method, p, query}, null, 2));
 
     if (method === 'POST') {
-      let {email, code, token, discordcode, discordid, twittercode, twitterid, autoip, mnemonic, signature, nonce} = query;
+      let {email, code, token, discordcode, discordid, twittercode, twitterid, autoip, mnemonic, signature, nonce, redirect_uri} = query;
       if (email && emailRegex.test(email)) {
         if (token) {
           const tokenItem = await ddb.getItem({
@@ -628,7 +628,7 @@ try {
             code: discordcode,
             grant_type: 'authorization_code',
             scope: 'identify',
-            redirect_uri: 'https://webaverse.com/login',
+            redirect_uri: redirect_uri || 'https://webaverse.com/login',
           });
           proxyReq.end(s);
           proxyReq.on('error', err => {


### PR DESCRIPTION
By default the redirect_uri which is passed to the api backend is webaverse.com/login if the login request is coming from different host. Api backend won't be able to authenticate it. So a redirect_uri parameter is added in the query for the dynamic redirect URI.